### PR TITLE
update readme setup and usage info

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,11 @@ a [sprout](http://github.com/carrot/sprout) template for generating [roots exten
 ### Installation
 
 - `npm install sprout -g`
-- `sprout add node https://github.com/kylemac/sprout-roots-extension.git`
+- `sprout add roots_ext https://github.com/carrot/sprout-roots-extension.git`
+
+### Usage
+
+`sprout init roots_ext <your_project_name>`
 
 ### Options
 


### PR DESCRIPTION
Small updates to the readme.
- use `roots_ext` in the CLI setup example
- use carrot's repo in the example
- add usage instructions
